### PR TITLE
simplified link factory with reused proxy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
   </scm>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <jmh.version>1.11.3</jmh.version>
   </properties>
   <developers>
     <developer>
@@ -244,6 +245,18 @@
    	<artifactId>javax.inject</artifactId>
    	<version>1</version>
    </dependency>
+      <dependency>
+          <groupId>org.openjdk.jmh</groupId>
+          <artifactId>jmh-core</artifactId>
+          <version>${jmh.version}</version>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.openjdk.jmh</groupId>
+          <artifactId>jmh-generator-annprocess</artifactId>
+          <version>${jmh.version}</version>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
   <profiles>
     <profile>

--- a/src/main/java/com/mercateo/common/rest/schemagen/JsonSchemaGenerator.java
+++ b/src/main/java/com/mercateo/common/rest/schemagen/JsonSchemaGenerator.java
@@ -2,31 +2,31 @@ package com.mercateo.common.rest.schemagen;
 
 import java.util.Optional;
 
-import com.mercateo.common.rest.schemagen.link.ScopeMethod;
+import com.mercateo.common.rest.schemagen.link.Scope;
 import com.mercateo.common.rest.schemagen.plugin.FieldCheckerForSchema;
 
 public interface JsonSchemaGenerator {
     /**
      * Creates the output schema for the given method applying a JsonView class
-     * 
-     * @param method
-     *            the method for which the output schema should be generated
+     *
+     * @param scope
+     *            the method scope for which the output schema should be generated
      * @param fieldCheckerForSchema
      *            checks for every field, if it should be included in the schema
      * @return Optional schema string
      */
-    Optional<String> createInputSchema(ScopeMethod method,
+    Optional<String> createInputSchema(Scope scope,
             FieldCheckerForSchema fieldCheckerForSchema);
 
     /**
      * Creates the output schema for the given method
      *
-     * @param method
-     *            the method for which the output schema should be generated
+     * @param scope
+     *            the method scope for which the output schema should be generated
      * @param fieldCheckerForSchema
      *            checks for every field, if it should be included in the schema
      * @return Optional schema string
      */
-    Optional<String> createOutputSchema(ScopeMethod method,
+    Optional<String> createOutputSchema(Scope scope,
             FieldCheckerForSchema fieldCheckerForSchema);
 }

--- a/src/main/java/com/mercateo/common/rest/schemagen/link/CallScope.java
+++ b/src/main/java/com/mercateo/common/rest/schemagen/link/CallScope.java
@@ -1,0 +1,19 @@
+package com.mercateo.common.rest.schemagen.link;
+
+import com.mercateo.common.rest.schemagen.parameter.CallContext;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+public class CallScope extends Scope {
+    private final Optional<CallContext> callContext;
+
+    public CallScope(Class<?> clazz, Method method, Object[] params, CallContext callContext) {
+        super(clazz, method, params);
+        this.callContext = Optional.ofNullable(callContext);
+    }
+
+    public Optional<CallContext> getCallContext() {
+        return callContext;
+    }
+}

--- a/src/main/java/com/mercateo/common/rest/schemagen/link/LinkFactory.java
+++ b/src/main/java/com/mercateo/common/rest/schemagen/link/LinkFactory.java
@@ -1,16 +1,13 @@
 package com.mercateo.common.rest.schemagen.link;
 
-import static java.util.Objects.requireNonNull;
-
+import javax.ws.rs.core.Link;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
-
-import javax.ws.rs.core.Link;
 
 import com.mercateo.common.rest.schemagen.JerseyResource;
 import com.mercateo.common.rest.schemagen.link.helper.InvocationRecorder;
+import com.mercateo.common.rest.schemagen.link.helper.InvocationRecordingResult;
 import com.mercateo.common.rest.schemagen.link.helper.MethodInvocation;
 import com.mercateo.common.rest.schemagen.link.helper.ProxyFactory;
 import com.mercateo.common.rest.schemagen.link.relation.Relation;
@@ -22,16 +19,16 @@ public class LinkFactory<T extends JerseyResource> {
 
     private final List<Scope> scopes;
 
-    private final Class<T> resourceClass;
-
     private final LinkFactoryContext context;
 
     private final LinkCreator linkCreator;
 
+    private final T resourceProxy;
+
     LinkFactory(Class<T> resourceClass, LinkFactoryContext context, List<Scope> scopes) {
-        this.scopes = scopes != null ? scopes : new ArrayList<>();
-        this.resourceClass = requireNonNull(resourceClass);
+        this.resourceProxy = ProxyFactory.createProxy(resourceClass);
         this.context = context;
+        this.scopes = scopes != null ? scopes : new ArrayList<>();
         this.linkCreator = new LinkCreator(context);
     }
 
@@ -100,75 +97,46 @@ public class LinkFactory<T extends JerseyResource> {
      */
     public Optional<Link> forCall(Relation relation, MethodInvocation<T> methodInvocation,
             CallContext callContext) {
-        final List<Scope> scopes = new ArrayList<>();
-        scopes.addAll(this.scopes);
-        scopes.add(new Scope(resourceClass, methodInvocation));
+        final List<Scope> scopes = new ArrayList<>(this.scopes);
+        scopes.add(createCallScope(methodInvocation, callContext));
 
-        final List<InvocationRecorder> invocationRecorders = scopes.stream().map(
-                this::scopeToInvocationRecorder).collect(Collectors.toList());
-
-        if (invocationRecorders.stream().allMatch(this::withAllPermissions)) {
-            final List<ScopeMethod> scopeMethods = invocationRecorders.stream().map(
-                    x -> invocationRecorderToScopeMethod(x, callContext)).collect(Collectors
-                            .toList());
-            return Optional.of(linkCreator.createFor(scopeMethods, relation));
+        if (scopes.stream().allMatch(this::hasAllPermissions)) {
+            return Optional.of(linkCreator.createFor(scopes, relation));
         }
         return Optional.empty();
     }
 
     public <U extends JerseyResource> LinkFactory<U> subResource(
             MethodInvocation<T> methodInvocation, Class<U> subResourceClass) {
-        return new LinkFactory<>(subResourceClass, context, new ArrayList<Scope>() {
+        return new LinkFactory<>(subResourceClass, context, new ArrayList<Scope>(scopes) {
             private static final long serialVersionUID = -9144825887185625018L;
-
             {
-                addAll(scopes);
-                add(new Scope(LinkFactory.this.resourceClass, methodInvocation));
+                add(createSubresourceScope(methodInvocation));
             }
         });
     }
 
-    private ScopeMethod invocationRecorderToScopeMethod(InvocationRecorder invocationRecorder,
-            CallContext context) {
-        return new ScopeMethod(invocationRecorder.getInvocationRecordingResult(), context);
+    private Scope createCallScope(MethodInvocation<T> methodInvocation, CallContext callContext) {
+        final InvocationRecordingResult result = recordMethodCall(methodInvocation);
+        return new CallScope(result.getInvokedClass(), result.getMethod(), result.getParams(), callContext);
     }
 
-    private boolean withAllPermissions(InvocationRecorder invocationRecorder) {
-        ScopeMethod scopeMethod = new ScopeMethod(invocationRecorder
-                .getInvocationRecordingResult());
-        return context == null || context.getMethodCheckerForLink().test(scopeMethod);
+    private Scope createSubresourceScope(MethodInvocation<T> methodInvocation) {
+        final InvocationRecordingResult result = recordMethodCall(methodInvocation);
+        return new SubResourceScope(result.getInvokedClass(), result.getMethod(), result.getParams());
     }
 
-    @SuppressWarnings("unchecked")
-    private <U extends JerseyResource> InvocationRecorder scopeToInvocationRecorder(Scope scope) {
-        // we know that ResourceClass and MethodInvocation match each other, so
-        // the casts are safe
-        final Class<U> clazz = (Class<U>) scope.getResourceClass();
-        final MethodInvocation<U> methodInvocation = (MethodInvocation<U>) scope
-                .getMethodInvocation();
-
-        U t = ProxyFactory.createProxy(clazz);
-        methodInvocation.record(t);
-        return (InvocationRecorder) t;
-    }
-
-    static class Scope {
-        private final Class<? extends JerseyResource> resourceClass;
-
-        private final MethodInvocation<? extends JerseyResource> lambda;
-
-        public <T extends JerseyResource> Scope(Class<T> resourceClass,
-                MethodInvocation<T> lambda) {
-            this.resourceClass = requireNonNull(resourceClass);
-            this.lambda = requireNonNull(lambda);
+    private InvocationRecordingResult recordMethodCall(MethodInvocation<T> methodInvocation) {
+        final InvocationRecordingResult result;
+        synchronized (resourceProxy) {
+            methodInvocation.record(resourceProxy);
+            result = ((InvocationRecorder) resourceProxy).getInvocationRecordingResult();
         }
-
-        public Class<? extends JerseyResource> getResourceClass() {
-            return resourceClass;
-        }
-
-        public MethodInvocation<? extends JerseyResource> getMethodInvocation() {
-            return lambda;
-        }
+        return result;
     }
+
+    private boolean hasAllPermissions(Scope scope) {
+        return context == null || context.getMethodCheckerForLink().test(scope);
+    }
+
 }

--- a/src/main/java/com/mercateo/common/rest/schemagen/link/Scope.java
+++ b/src/main/java/com/mercateo/common/rest/schemagen/link/Scope.java
@@ -1,0 +1,91 @@
+package com.mercateo.common.rest.schemagen.link;
+
+import com.googlecode.gentyref.GenericTypeReflector;
+import com.mercateo.common.rest.schemagen.link.helper.InvocationRecordingResult;
+import com.mercateo.common.rest.schemagen.parameter.CallContext;
+import com.mercateo.common.rest.schemagen.parameter.Parameter;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
+
+public abstract class Scope {
+    private final Class<?> invokedClass;
+
+    private final Method invokedMethod;
+
+    private final Object[] params;
+
+    public Scope(Class<?> clazz, Method method, Object[] params) {
+        this.invokedClass = requireNonNull(clazz);
+        this.invokedMethod = requireNonNull(method);
+        this.params = requireNonNull(params);
+    }
+
+    public Method getInvokedMethod() {
+        return invokedMethod;
+    }
+
+    public Object[] getParams() {
+        return params;
+    }
+
+    public Class<?> getInvokedClass() {
+        return invokedClass;
+    }
+
+    public Type[] getParameterTypes() {
+        return GenericTypeReflector.getExactParameterTypes(invokedMethod, invokedClass);
+    }
+
+    public Type getReturnType() {
+        return GenericTypeReflector.getExactReturnType(invokedMethod, invokedClass);
+    }
+
+    public Annotation[] getAnnotations() {
+        return invokedMethod.getAnnotations();
+    }
+
+    public String getName() {
+        return invokedMethod.getName();
+    }
+
+    public abstract Optional<CallContext> getCallContext();
+
+    @SuppressWarnings("boxing")
+    public boolean hasAllowedValues(int argumentIndex) {
+        return getValues(argumentIndex, Parameter::hasAllowedValues, false);
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<Object> getAllowedValues(int argumentIndex) {
+        return getValues(argumentIndex, p -> (List<Object>) p.getAllowedValues(), Collections
+                .emptyList());
+    }
+
+    @SuppressWarnings("boxing")
+    public boolean hasDefaultValue(int argumentIndex) {
+        return getValues(argumentIndex, Parameter::hasDefaultValue, true);
+    }
+
+    public Object getDefaultValue(int argumentIndex) {
+        return getValues(argumentIndex, Parameter::getDefaultValue, null);
+    }
+
+    private <T> T getValues(int argumentIndex, Function<Parameter<?>, T> map, T negativeValue) {
+        if (argumentIndex < params.length) {
+            final Object argument = params[argumentIndex];
+            return getCallContext()
+                    .filter(callContext -> callContext.hasParameter(argument))
+                    .map(callContext -> map.apply(callContext.getParameter(argument)))
+                    .orElse(negativeValue);
+        }
+        return negativeValue;
+    }
+}

--- a/src/main/java/com/mercateo/common/rest/schemagen/link/ScopeMethod.java
+++ b/src/main/java/com/mercateo/common/rest/schemagen/link/ScopeMethod.java
@@ -1,114 +1,12 @@
 package com.mercateo.common.rest.schemagen.link;
 
-import static java.util.Objects.requireNonNull;
-
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.lang.reflect.Type;
-import java.util.Collections;
-import java.util.List;
-import java.util.function.Function;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.googlecode.gentyref.GenericTypeReflector;
-import com.mercateo.common.rest.schemagen.link.helper.InvocationRecordingResult;
-import com.mercateo.common.rest.schemagen.parameter.CallContext;
-import com.mercateo.common.rest.schemagen.parameter.Parameter;
-
-public class ScopeMethod {
-    private final Method invokedMethod;
-
-    private final Object[] params;
-
-    private final CallContext callContext;
-
-    private final Class<?> invokedClass;
-
-    public ScopeMethod(InvocationRecordingResult invocationRecordingResult) {
-        this(invocationRecordingResult, CallContext.create());
-    }
-
-    public ScopeMethod(InvocationRecordingResult invocationRecordingResult,
-            CallContext callContext) {
-        this.invokedMethod = requireNonNull(invocationRecordingResult.getMethod());
-        this.params = requireNonNull(invocationRecordingResult.getParams());
-        this.invokedClass = requireNonNull(invocationRecordingResult.getInvokedClass());
-        this.callContext = callContext;
-    }
-
-    @VisibleForTesting
-    protected ScopeMethod(Method invokedMethod, Object[] params, Class<?> invokedClass) {
-        this(invokedMethod, params, invokedClass, CallContext.create());
-    }
-
-    @VisibleForTesting
-    protected ScopeMethod(Method invokedMethod, Object[] params, Class<?> invokedClass,
-            CallContext callContext) {
-        this.invokedMethod = requireNonNull(invokedMethod);
-        this.params = requireNonNull(params);
-        this.invokedClass = requireNonNull(invokedClass);
-        this.callContext = callContext;
-    }
-
-    public Method getInvokedMethod() {
-        return invokedMethod;
-    }
-
-    public Object[] getParams() {
-        return params;
-    }
-
-    public Class<?> getInvokedClass() {
-        return invokedClass;
-    }
-
-    public Type[] getParameterTypes() {
-        return GenericTypeReflector.getExactParameterTypes(invokedMethod, invokedClass);
-    }
-
-    public Type getReturnType() {
-        return GenericTypeReflector.getExactReturnType(invokedMethod, invokedClass);
-    }
-
-    public Annotation[] getAnnotations() {
-        return invokedMethod.getAnnotations();
-    }
-
-    public String getName() {
-        return invokedMethod.getName();
-    }
-
-    public CallContext getCallContext() {
-        return callContext;
-    }
-
-    @SuppressWarnings("boxing")
-    public boolean hasAllowedValues(int argumentIndex) {
-        return getValues(argumentIndex, Parameter::hasAllowedValues, false);
-    }
-
-    @SuppressWarnings("unchecked")
-    public List<Object> getAllowedValues(int argumentIndex) {
-        return getValues(argumentIndex, p -> (List<Object>) p.getAllowedValues(), Collections
-                .emptyList());
-    }
-
-    @SuppressWarnings("boxing")
-    public boolean hasDefaultValue(int argumentIndex) {
-        return getValues(argumentIndex, Parameter::hasDefaultValue, true);
-    }
-
-    public Object getDefaultValue(int argumentIndex) {
-        return getValues(argumentIndex, Parameter::getDefaultValue, null);
-    }
-
-    private <T> T getValues(int argumentIndex, Function<Parameter<?>, T> map, T negativeValue) {
-        if (argumentIndex < params.length) {
-            final Object argument = params[argumentIndex];
-            if (callContext != null && callContext.hasParameter(argument)) {
-                return map.apply(callContext.getParameter(argument));
-            }
-        }
-        return negativeValue;
+/**
+ * @deprecated please use {@link Scope} instead
+ */
+public abstract class ScopeMethod extends Scope {
+    public ScopeMethod(Class<?> clazz, Method method, Object[] params) {
+        super(clazz, method, params);
     }
 }

--- a/src/main/java/com/mercateo/common/rest/schemagen/link/SubResourceScope.java
+++ b/src/main/java/com/mercateo/common/rest/schemagen/link/SubResourceScope.java
@@ -1,0 +1,18 @@
+package com.mercateo.common.rest.schemagen.link;
+
+import com.mercateo.common.rest.schemagen.parameter.CallContext;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+public class SubResourceScope extends Scope {
+
+    public SubResourceScope(Class<?> clazz, Method method, Object[] params) {
+        super(clazz, method, params);
+    }
+
+    @Override
+    public Optional<CallContext> getCallContext() {
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/mercateo/common/rest/schemagen/plugin/MethodCheckerForLink.java
+++ b/src/main/java/com/mercateo/common/rest/schemagen/plugin/MethodCheckerForLink.java
@@ -2,7 +2,7 @@ package com.mercateo.common.rest.schemagen.plugin;
 
 import java.util.function.Predicate;
 
-import com.mercateo.common.rest.schemagen.link.ScopeMethod;
+import com.mercateo.common.rest.schemagen.link.Scope;
 
 /**
  * Checks if a link should be created for that method.
@@ -10,9 +10,9 @@ import com.mercateo.common.rest.schemagen.link.ScopeMethod;
  * @author joerg_adler
  *
  */
-public interface MethodCheckerForLink extends Predicate<ScopeMethod> {
+public interface MethodCheckerForLink extends Predicate<Scope> {
 
-    static MethodCheckerForLink fromPredicate(Predicate<ScopeMethod> predicate) {
+    static MethodCheckerForLink fromPredicate(Predicate<Scope> predicate) {
         return s -> predicate.test(s);
     }
 

--- a/src/main/java/com/mercateo/common/rest/schemagen/plugin/common/RolesAllowedChecker.java
+++ b/src/main/java/com/mercateo/common/rest/schemagen/plugin/common/RolesAllowedChecker.java
@@ -10,7 +10,7 @@ import javax.ws.rs.core.SecurityContext;
 import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
 import org.glassfish.jersey.server.model.AnnotatedMethod;
 
-import com.mercateo.common.rest.schemagen.link.ScopeMethod;
+import com.mercateo.common.rest.schemagen.link.Scope;
 import com.mercateo.common.rest.schemagen.plugin.MethodCheckerForLink;
 
 /**
@@ -28,9 +28,9 @@ public class RolesAllowedChecker implements MethodCheckerForLink {
     }
 
     @Override
-    public boolean test(ScopeMethod scopeMethod) {
+    public boolean test(Scope scope) {
 
-        AnnotatedMethod am = new AnnotatedMethod(scopeMethod.getInvokedMethod());
+        AnnotatedMethod am = new AnnotatedMethod(scope.getInvokedMethod());
 
         // DenyAll on the method take precedence over RolesAllowed and PermitAll
         if (am.isAnnotationPresent(DenyAll.class)) {
@@ -52,7 +52,7 @@ public class RolesAllowedChecker implements MethodCheckerForLink {
         // DenyAll can't be attached to classes
 
         // RolesAllowed on the class takes precedence over PermitAll
-        ra = scopeMethod.getInvokedClass().getAnnotation(RolesAllowed.class);
+        ra = scope.getInvokedClass().getAnnotation(RolesAllowed.class);
         if (ra != null) {
             return checkRoles(ra.value());
         }

--- a/src/test/java/com/mercateo/common/rest/schemagen/Benchmarks.java
+++ b/src/test/java/com/mercateo/common/rest/schemagen/Benchmarks.java
@@ -1,0 +1,41 @@
+package com.mercateo.common.rest.schemagen;
+
+import com.mercateo.common.rest.schemagen.link.LinkFactory;
+import com.mercateo.common.rest.schemagen.link.LinkMetaFactory;
+import com.mercateo.common.rest.schemagen.link.relation.Rel;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import javax.ws.rs.core.Link;
+import java.util.Optional;
+
+public class Benchmarks {
+
+    private static final LinkMetaFactory linkMetaFactory = LinkMetaFactory.createInsecureFactoryForTest();
+
+    private static final LinkFactory<ResourceClass> linkFactory = linkMetaFactory.createFactoryFor(ResourceClass.class);
+
+    @Benchmark
+    public static void createLinkFactory() {
+        final LinkFactory<ResourceClass> linkFactory = linkMetaFactory.createFactoryFor(ResourceClass.class);
+    }
+
+    @Benchmark
+    public static void createLink() {
+        final Optional<Link> link = linkFactory.forCall(Rel.SELF, r -> r.postSomething(null));
+    }
+
+    public static void main(String[] args) throws RunnerException, InterruptedException {
+
+        Options opt = new OptionsBuilder()
+                .warmupIterations(10)
+                .measurementIterations(10)
+                .forks(1)
+                .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/com/mercateo/common/rest/schemagen/link/LinkCreatorTest.java
+++ b/src/test/java/com/mercateo/common/rest/schemagen/link/LinkCreatorTest.java
@@ -72,11 +72,10 @@ public class LinkCreatorTest {
         implementedBeanParamType.setPathParam("path");
         implementedBeanParamType.setQueryParam1("v1");
         implementedBeanParamType.setQueryParam2("v2");
-        ScopeMethod scopeMethod = new ScopeMethod(ImplementedGenricResource.class.getMethod("get",
-                Object.class), new Object[] { implementedBeanParamType },
-                ImplementedGenricResource.class);
+        Scope scope = new CallScope(ImplementedGenricResource.class, ImplementedGenricResource.class.getMethod("get",
+                Object.class), new Object[] { implementedBeanParamType }, null);
 
-        Link link = createFor(scopeMethod, Relation.of(Rel.SELF), URI.create(
+        Link link = createFor(scope, Relation.of(Rel.SELF), URI.create(
                 "http://localhost:8080/"));
 
         assertEquals("http://localhost:8080/test/path?qp2=v2&qp1=v1", link.getUri().toString());
@@ -98,11 +97,10 @@ public class LinkCreatorTest {
         ImplementedBeanParamType implementedBeanParamType = new ImplementedBeanParamType();
         implementedBeanParamType.setPathParam("path");
 
-        ScopeMethod scopeMethod = new ScopeMethod(ImplementedGenricResource.class.getMethod("get",
-                Object.class), new Object[] { implementedBeanParamType },
-                ImplementedGenricResource.class);
+        Scope scope = new CallScope(ImplementedGenricResource.class, ImplementedGenricResource.class.getMethod("get",
+                Object.class), new Object[] { implementedBeanParamType }, null );
 
-        Link link = createFor(scopeMethod, Relation.of(Rel.SELF), URI.create(
+        Link link = createFor(scope, Relation.of(Rel.SELF), URI.create(
                 "http://localhost:8080/"));
 
         assertEquals("http://localhost:8080/test/path", link.getUri().toString());
@@ -125,11 +123,10 @@ public class LinkCreatorTest {
         ImplementedBeanParamType implementedBeanParamType = new ImplementedBeanParamType();
         implementedBeanParamType.setPathParam("path");
         implementedBeanParamType.setElements("foo", "bar", "baz");
-        ScopeMethod scopeMethod = new ScopeMethod(ImplementedGenricResource.class.getMethod("get",
-                Object.class), new Object[] { implementedBeanParamType },
-                ImplementedGenricResource.class);
+        Scope scope = new CallScope(ImplementedGenricResource.class, ImplementedGenricResource.class.getMethod("get",
+                Object.class), new Object[] { implementedBeanParamType }, null);
 
-        Link link = createFor(scopeMethod, Relation.of(Rel.SELF), URI.create(
+        Link link = createFor(scope, Relation.of(Rel.SELF), URI.create(
                 "http://localhost:8080/"));
 
         assertEquals("http://localhost:8080/test/path?elements=foo&elements=bar&elements=baz", link
@@ -148,10 +145,10 @@ public class LinkCreatorTest {
 
     private Link createFor(Class<?> invokedClass, Method method, Relation relation, URI baseUri,
             Object... params) {
-        return createFor(new ScopeMethod(method, params, invokedClass), relation, baseUri);
+        return createFor(new CallScope(invokedClass, method, params, null), relation, baseUri);
     }
 
-    private Link createFor(ScopeMethod method, Relation relation, URI baseURI) {
+    private Link createFor(Scope method, Relation relation, URI baseURI) {
         final JsonSchemaGenerator jsonSchemaGenerator = createJsonSchemaGenerator();
 
         final LinkFactoryContext linkFactoryContext = new LinkFactoryContext(jsonSchemaGenerator,


### PR DESCRIPTION
This PR simplifies the recording of the resource method calls on the instrumented proxy. In addition the instrumented proxy is reused on the level of each individual link factory.

Some simple Benchmark was added to compare the performance of link factory and link schema generation.