### PR TITLE
externalize validation error codes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
       <plugin>
         <groupId>org.eluder.coveralls</groupId>
         <artifactId>coveralls-maven-plugin</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
       </plugin>
     </plugins>
  </build>

--- a/src/main/java/com/mercateo/common/rest/schemagen/validation/ValidationErrors.java
+++ b/src/main/java/com/mercateo/common/rest/schemagen/validation/ValidationErrors.java
@@ -24,7 +24,7 @@ public class ValidationErrors {
             validationErrors = new ArrayList<>();
         }
 
-        public Builder addError(ValidationErrorCode code, String path) {
+        public Builder addError(ValidationErrorCodeContainer code, String path) {
             HashMap<MessageKey, String> entries = new HashMap<>();
             entries.put(MessageKey.path, path);
             addError(new ValidationError(code, entries));
@@ -65,9 +65,9 @@ public class ValidationErrors {
             return entries;
         }
 
-        public ValidationError(ValidationErrorCode code, HashMap<MessageKey, String> otherEntries) {
+        public ValidationError(ValidationErrorCodeContainer code, HashMap<MessageKey, String> otherEntries) {
             HashMap<MessageKey, String> entries = new HashMap<>();
-            entries.put(MessageKey.validationErrorCode, code.toString());
+            entries.put(MessageKey.validationErrorCode, code.name());
             if (otherEntries != null) {
                 entries.putAll(otherEntries);
             }
@@ -80,9 +80,20 @@ public class ValidationErrors {
         validationErrorCode, path, minimum, maximum
     }
 
-    public enum ValidationErrorCode {
+    @Deprecated
+    /**
+     * @deprecated
+     *
+     * This Enum should be implemented inside the specific service project.
+     *
+     */
+    public enum ValidationErrorCode implements ValidationErrorCodeContainer {
         REQUIRED, UNKNOWN, STRING_LENGTH_SHORT, STRING_LENGTH_LONG, DUPLICATE,
         NO_PACKSTATION_ALLOWED, NO_POST_OFFICE_BOX_ALLOWED, NO_VALID_EMAIL, UNRECOGNIZED_FIELD,
         VALUE_BELOW_MIN, VALUE_ABOVE_MAX, NO_VALID_ZIP, USER_EXISTS, WRONG_PASSWORD
+    }
+
+    public interface ValidationErrorCodeContainer {
+        String name();
     }
 }

--- a/src/test/java/com/mercateo/common/rest/schemagen/validation/ValidationErrorTest.java
+++ b/src/test/java/com/mercateo/common/rest/schemagen/validation/ValidationErrorTest.java
@@ -20,7 +20,7 @@ public class ValidationErrorTest {
     @Test
     public void testAddValidationErrorWithCodeAndPath() {
         final String errorLocation = "#/foo";
-        final ValidationErrors.ValidationErrorCode errorCode = ValidationErrors.ValidationErrorCode.REQUIRED;
+        final TestValidationErrorCode errorCode = TestValidationErrorCode.REQUIRED;
         final ValidationErrors.Data validationErrorsData = ValidationErrors.builder().addError(
                 errorCode, errorLocation).build();
 
@@ -34,7 +34,7 @@ public class ValidationErrorTest {
 
     @Test
     public void testValidationErrorAdd() {
-        final ValidationErrors.ValidationErrorCode errorCode = ValidationErrors.ValidationErrorCode.DUPLICATE;
+        final TestValidationErrorCode errorCode = TestValidationErrorCode.DUPLICATE;
 
         final ValidationErrors.ValidationError validationError = new ValidationErrors.ValidationError(errorCode, new HashMap<>());
 
@@ -49,5 +49,9 @@ public class ValidationErrorTest {
                 .hasSize(2) //
                 .containsEntry(ValidationErrors.MessageKey.validationErrorCode, errorCode.toString())
                 .containsEntry(ValidationErrors.MessageKey.maximum, maximumValue);
+    }
+
+    public enum TestValidationErrorCode implements ValidationErrors.ValidationErrorCodeContainer {
+        REQUIRED, DUPLICATE
     }
 }


### PR DESCRIPTION
The Enum ValidationErrorCode should be implemented in the project using the schema generator dependency.

Any enum implementing ValidationErrorCodeContainer can now be used to specify error codes.

The existing ValidationErrorCode was deprecated to be removed later.