### PR TITLE
test and fix enum map dict representation

### DIFF
--- a/src/main/java/com/mercateo/common/rest/schemagen/PropertyBuilder.java
+++ b/src/main/java/com/mercateo/common/rest/schemagen/PropertyBuilder.java
@@ -1,20 +1,17 @@
 package com.mercateo.common.rest.schemagen;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.fasterxml.jackson.annotation.JsonValue;
 import com.mercateo.common.rest.schemagen.generator.ObjectContext;
 import com.mercateo.common.rest.schemagen.generictype.GenericType;
 import com.mercateo.common.rest.schemagen.plugin.IndividualSchemaGenerator;
+import com.mercateo.common.rest.schemagen.util.EnumUtil;
 
 public class PropertyBuilder {
 
@@ -95,7 +92,7 @@ public class PropertyBuilder {
     @SuppressWarnings("unchecked")
     private String convertToString(Object defaultValue) {
         if (Enum.class.isAssignableFrom(rawType)) {
-            return convertEnumToString((Enum<? extends Enum<?>>) defaultValue);
+            return EnumUtil.convertToString((Enum<? extends Enum<?>>) defaultValue);
         } else {
             return defaultValue.toString();
         }
@@ -113,24 +110,9 @@ public class PropertyBuilder {
     @SuppressWarnings("unchecked")
     private List<String> convertToStrings(Object x) {
         if (Enum.class.isAssignableFrom(rawType)) {
-            return Collections.singletonList(convertEnumToString((Enum<? extends Enum<?>>) x));
+            return Collections.singletonList(EnumUtil.convertToString((Enum<? extends Enum<?>>) x));
         } else {
             return Arrays.asList(x.toString());
-        }
-    }
-
-    private String convertEnumToString(Enum<? extends Enum<?>> x) {
-        final Optional<Method> valueMethod = Stream.of(x.getClass().getDeclaredMethods()).filter(
-                m -> m.isAnnotationPresent(JsonValue.class)).findFirst();
-
-        if (valueMethod.isPresent()) {
-            try {
-                return valueMethod.get().invoke(x).toString();
-            } catch (IllegalAccessException | InvocationTargetException e) {
-                throw new RuntimeException(e);
-            }
-        } else {
-            return x.name();
         }
     }
 
@@ -206,7 +188,7 @@ public class PropertyBuilder {
         if (this.allowedValues != null && !this.allowedValues.isEmpty()) {
             return this.allowedValues;
         } else if (Enum.class.isAssignableFrom(rawType)) {
-            return Stream.of(rawType.getEnumConstants()).map(e -> convertEnumToString(
+            return Stream.of(rawType.getEnumConstants()).map(e -> EnumUtil.convertToString(
                     (Enum<? extends Enum<?>>) e)).collect(Collectors.toList());
         } else {
             return Collections.emptyList();

--- a/src/main/java/com/mercateo/common/rest/schemagen/SchemaPropertyGenerator.java
+++ b/src/main/java/com/mercateo/common/rest/schemagen/SchemaPropertyGenerator.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import com.mercateo.common.rest.schemagen.generator.ObjectContext;
 import com.mercateo.common.rest.schemagen.generator.PathContext;
 import com.mercateo.common.rest.schemagen.generictype.GenericType;
+import com.mercateo.common.rest.schemagen.util.EnumUtil;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
@@ -223,7 +224,7 @@ public class SchemaPropertyGenerator {
 
         return Stream.of(keyType.getEnumConstants())
                 .map(enumConstant -> {
-                    final String enumName = ((Enum<?>) enumConstant).name();
+                    final String enumName = EnumUtil.convertToString((Enum<?>) enumConstant);
                     return updateName(objectContext, valueProperty, enumName);
                 }).collect(Collectors.toList());
     }

--- a/src/main/java/com/mercateo/common/rest/schemagen/util/EnumUtil.java
+++ b/src/main/java/com/mercateo/common/rest/schemagen/util/EnumUtil.java
@@ -1,0 +1,30 @@
+package com.mercateo.common.rest.schemagen.util;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public final class EnumUtil {
+    private EnumUtil() {
+    }
+
+    public static String convertToString(Enum<? extends Enum<?>> x) {
+        final Optional<Method> optionalValueMethod = Stream.of(x.getClass().getDeclaredMethods()).filter(
+                m -> m.isAnnotationPresent(JsonValue.class)).findFirst();
+
+        if (optionalValueMethod.isPresent()) {
+            try {
+                final Method valueMethod = optionalValueMethod.get();
+                valueMethod.setAccessible(true);
+                return valueMethod.invoke(x).toString();
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            return x.name();
+        }
+    }
+}

--- a/src/test/java/com/mercateo/common/rest/schemagen/RestJsonSchemaGeneratorTest.java
+++ b/src/test/java/com/mercateo/common/rest/schemagen/RestJsonSchemaGeneratorTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.base.CaseFormat.*;
 
 @SuppressWarnings({"boxing", "unused"})
 @RunWith(MockitoJUnitRunner.class)
@@ -178,6 +179,18 @@ public class RestJsonSchemaGeneratorTest {
     }
 
     @Test
+    public void createInputSchemaWithEnumParamWithJsonValue() throws NoSuchMethodException {
+        final Method enumValue = getTestResourceMethod("enumValueJsonValue", TestEnumJsonValue.class);
+        final Optional<String> inputSchema = schemaGenerator.createInputSchema(new CallScope(TestResource.class,
+                enumValue, new Object[]{null}, CallContext.create()) {
+        }, fieldCheckerForSchema);
+
+        assertThat(inputSchema.isPresent()).isTrue();
+        assertThat(inputSchema.get()).containsIgnoringCase(
+                "{\"type\":\"string\",\"enum\":[\"fooValue\",\"barValue\"]}");
+    }
+
+    @Test
     public void createInputSchemaWithMediaParam() {
         final Method enumValue = getTestResourceMethod("media", String.class);
         final Optional<String> inputSchema = schemaGenerator.createInputSchema(new CallScope(TestResource.class,
@@ -199,6 +212,15 @@ public class RestJsonSchemaGeneratorTest {
 
     public enum TestEnum {
         FOO_VALUE, BAR_VALUE;
+    }
+
+    public enum TestEnumJsonValue {
+        FOO_VALUE, BAR_VALUE;
+
+        @JsonValue
+        public String getValue() {
+            return UPPER_UNDERSCORE.to(LOWER_CAMEL, name());
+        }
     }
 
     public static class TestBeanParam {
@@ -257,6 +279,12 @@ public class RestJsonSchemaGeneratorTest {
         @GET
         @Path("/enumValue")
         public void enumValue(TestEnum enumValue) {
+            // Nothing to do
+        }
+
+        @GET
+        @Path("/enumValueJsonValue")
+        public void enumValueJsonValue(TestEnumJsonValue enumValue) {
             // Nothing to do
         }
 

--- a/src/test/java/com/mercateo/common/rest/schemagen/SchemaPropertyGeneratorTest.java
+++ b/src/test/java/com/mercateo/common/rest/schemagen/SchemaPropertyGeneratorTest.java
@@ -1,5 +1,7 @@
 package com.mercateo.common.rest.schemagen;
 
+import static com.google.common.base.CaseFormat.LOWER_CAMEL;
+import static com.google.common.base.CaseFormat.UPPER_UNDERSCORE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -9,6 +11,7 @@ import java.util.*;
 
 import javax.ws.rs.PathParam;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -378,6 +381,26 @@ public class SchemaPropertyGeneratorTest {
     }
 
     @Test
+    public void testObjectWithMapAsDictWithEnumJsonValue() {
+        final Property property = generateSchemaProperty(SchemaObjectWithMapAsDictEnumJsonValue.class);
+        assertThat(property.getType()).isEqualTo(PropertyType.OBJECT);
+        List<Property> properties = property.getProperties();
+        assertThat(properties).hasSize(1);
+
+        final List<Property> dictProperties = properties.get(0).getProperties();
+
+        assertThat(dictProperties.get(0).getName()).isEqualTo("fooOne");
+        assertThat(dictProperties.get(0).getType()).isEqualTo(PropertyType.ARRAY);
+        List<Property> innerArrayProperties = dictProperties.get(0).getProperties();
+        assertThat(innerArrayProperties).hasSize(1);
+
+        assertThat(dictProperties.get(1).getName()).isEqualTo("barTwo");
+        assertThat(dictProperties.get(1).getType()).isEqualTo(PropertyType.ARRAY);
+        innerArrayProperties = dictProperties.get(1).getProperties();
+        assertThat(innerArrayProperties).hasSize(1);
+    }
+
+    @Test
     public void testObjectWithUnwrappedContent() {
         Property property = generateSchemaProperty(SchemaObjectWithUnwrappedContent.class);
         assertThat(property.getName()).isEqualTo("SchemaObjectWithUnwrappedContent");
@@ -549,6 +572,15 @@ public class SchemaPropertyGeneratorTest {
         FOO, BAR
     }
 
+    enum TestEnumJsonValue {
+        FOO_ONE, BAR_TWO;
+
+        @JsonValue
+        public String getValue() {
+            return UPPER_UNDERSCORE.to(LOWER_CAMEL, name());
+        }
+    }
+
     public static class TestClassWithBuiltins {
         public Date timestamp;
 
@@ -602,6 +634,10 @@ public class SchemaPropertyGeneratorTest {
 
     public static class SchemaObjectWithMapAsDict {
         public Map<TestEnum, List<String>> valuesByKey;
+    }
+
+    public static class SchemaObjectWithMapAsDictEnumJsonValue {
+        public Map<TestEnumJsonValue, List<String>> valuesByKey;
     }
 
     public static class SchemaObjectWithUnwrappedContent {


### PR DESCRIPTION
The enum map dictionary support which was added with PR #14 does not honor a @JsonValue annotation for the enum representation. This PR adds tests and fixes this behaviour.