### PR TITLE
deprecate applications specific validation errors only

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
   <dependency>
   	<groupId>org.assertj</groupId>
   	<artifactId>assertj-core</artifactId>
-  	<version>3.2.0</version>
+  	<version>3.3.0</version>
   	<scope>test</scope>
   </dependency>
   <dependency>

--- a/src/main/java/com/mercateo/common/rest/schemagen/SizeConstraints.java
+++ b/src/main/java/com/mercateo/common/rest/schemagen/SizeConstraints.java
@@ -6,6 +6,8 @@ import javax.validation.constraints.Size;
 
 public class SizeConstraints {
 
+    private static final SizeConstraints EMPTY_CONSTRAINTS = new SizeConstraints();
+
     private Optional<Integer> max;
 
     private Optional<Integer> min;
@@ -28,7 +30,7 @@ public class SizeConstraints {
             throw new IllegalArgumentException(String.format(
                     "Minimum value %s is larger than maximum value %s", min, max));
         }
-        if (min < 0 || max < 0) {
+        if (min < 0) {
             throw new IllegalArgumentException("Supplied arguments must be non-negative");
         }
         this.max = max == Integer.MAX_VALUE ? Optional.empty() : Optional.of(max);
@@ -36,7 +38,7 @@ public class SizeConstraints {
     }
 
     public static SizeConstraints empty() {
-        return new SizeConstraints();
+        return EMPTY_CONSTRAINTS;
     }
 
     private SizeConstraints() {

--- a/src/main/java/com/mercateo/common/rest/schemagen/ValueConstraints.java
+++ b/src/main/java/com/mercateo/common/rest/schemagen/ValueConstraints.java
@@ -3,6 +3,9 @@ package com.mercateo.common.rest.schemagen;
 import java.util.Optional;
 
 public class ValueConstraints {
+
+    private static final ValueConstraints EMPTY_CONSTRAINTS = new ValueConstraints();
+
     private Optional<Long> max;
 
     private Optional<Long> min;
@@ -18,19 +21,18 @@ public class ValueConstraints {
     public ValueConstraints(Optional<Long> max, Optional<Long> min) {
         if (max.flatMap(x -> min.map(y -> y > x)).orElse(false)) {
             throw new IllegalArgumentException(String.format(
-                    "Minimum value %s is larger than maximum value %s", min, max));
+                    "Minimum value %s is larger than maximum value %s", min.get(), max.get()));
         }
         this.max = max;
         this.min = min;
     }
 
     public static ValueConstraints empty() {
-        return new ValueConstraints();
+        return EMPTY_CONSTRAINTS;
     }
 
     private ValueConstraints() {
         this.max = Optional.empty();
         this.min = Optional.empty();
     }
-
 }

--- a/src/main/java/com/mercateo/common/rest/schemagen/validation/ValidationErrors.java
+++ b/src/main/java/com/mercateo/common/rest/schemagen/validation/ValidationErrors.java
@@ -3,6 +3,7 @@ package com.mercateo.common.rest.schemagen.validation;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
@@ -65,7 +66,7 @@ public class ValidationErrors {
             return entries;
         }
 
-        public ValidationError(ValidationErrorCodeContainer code, HashMap<MessageKey, String> otherEntries) {
+        public ValidationError(ValidationErrorCodeContainer code, Map<MessageKey, String> otherEntries) {
             HashMap<MessageKey, String> entries = new HashMap<>();
             entries.put(MessageKey.validationErrorCode, code.name());
             if (otherEntries != null) {
@@ -73,24 +74,17 @@ public class ValidationErrors {
             }
             this.entries = entries;
         }
-
     }
 
     public enum MessageKey {
         validationErrorCode, path, minimum, maximum
     }
 
-    @Deprecated
-    /**
-     * @deprecated
-     *
-     * This Enum should be implemented inside the specific service project.
-     *
-     */
     public enum ValidationErrorCode implements ValidationErrorCodeContainer {
         REQUIRED, UNKNOWN, STRING_LENGTH_SHORT, STRING_LENGTH_LONG, DUPLICATE,
-        NO_PACKSTATION_ALLOWED, NO_POST_OFFICE_BOX_ALLOWED, NO_VALID_EMAIL, UNRECOGNIZED_FIELD,
-        VALUE_BELOW_MIN, VALUE_ABOVE_MAX, NO_VALID_ZIP, USER_EXISTS, WRONG_PASSWORD
+        @Deprecated NO_PACKSTATION_ALLOWED,
+        @Deprecated NO_POST_OFFICE_BOX_ALLOWED, @Deprecated NO_VALID_EMAIL, UNRECOGNIZED_FIELD,
+        VALUE_BELOW_MIN, VALUE_ABOVE_MAX, @Deprecated NO_VALID_ZIP, @Deprecated USER_EXISTS, WRONG_PASSWORD
     }
 
     public interface ValidationErrorCodeContainer {

--- a/src/test/java/com/mercateo/common/rest/schemagen/SizeConstraintsTest.java
+++ b/src/test/java/com/mercateo/common/rest/schemagen/SizeConstraintsTest.java
@@ -1,0 +1,60 @@
+package com.mercateo.common.rest.schemagen;
+
+import org.junit.Test;
+
+import javax.validation.constraints.Size;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SizeConstraintsTest {
+
+    @Test
+    public void constructorThrowsWithInvalidValues() {
+        Size size = mock(Size.class);
+        when(size.max()).thenReturn(2);
+        when(size.min()).thenReturn(5);
+
+        assertThatThrownBy(
+                () -> new SizeConstraints(size)
+        ).isInstanceOf(IllegalArgumentException.class).hasMessage("Minimum value 5 is larger than maximum value 2");
+    }
+
+    @Test
+    public void constructorThrowsWithNegativeMinValue() {
+        Size size = mock(Size.class);
+        when(size.max()).thenReturn(2);
+        when(size.min()).thenReturn(-2);
+
+        assertThatThrownBy(
+                () -> new SizeConstraints(size)
+        ).isInstanceOf(IllegalArgumentException.class).hasMessage("Supplied arguments must be non-negative");
+    }
+
+    @Test
+    public void defaultOperation() {
+        final Optional<Integer> max = Optional.of(7);
+        final Optional<Integer> min = Optional.of(4);
+
+        Size size = mock(Size.class);
+        when(size.max()).thenReturn(max.get());
+        when(size.min()).thenReturn(min.get());
+
+        final SizeConstraints sizeConstraints = new SizeConstraints(size);
+
+        assertThat(sizeConstraints.getMax()).isEqualTo(max);
+        assertThat(sizeConstraints.getMin()).isEqualTo(min);
+    }
+
+    @Test
+    public void emptyConstraint() {
+        final SizeConstraints sizeConstraints = SizeConstraints.empty();
+
+        assertThat(sizeConstraints.getMax()).isEmpty();
+        assertThat(sizeConstraints.getMin()).isEmpty();
+    }
+
+}

--- a/src/test/java/com/mercateo/common/rest/schemagen/ValueConstraintsTest.java
+++ b/src/test/java/com/mercateo/common/rest/schemagen/ValueConstraintsTest.java
@@ -1,0 +1,37 @@
+package com.mercateo.common.rest.schemagen;
+
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ValueConstraintsTest {
+
+    @Test
+    public void constructorThrowsWithInvalidValues() {
+        assertThatThrownBy(
+                () -> new ValueConstraints(Optional.of(2l), Optional.of(5l))
+        ).isInstanceOf(IllegalArgumentException.class).hasMessage("Minimum value 5 is larger than maximum value 2");
+    }
+
+    @Test
+    public void defaultOperation() {
+        final Optional<Long> max = Optional.of(7l);
+        final Optional<Long> min = Optional.of(4l);
+        final ValueConstraints valueConstraints = new ValueConstraints(max, min);
+
+        assertThat(valueConstraints.getMax()).isEqualTo(max);
+        assertThat(valueConstraints.getMin()).isEqualTo(min);
+    }
+
+    @Test
+    public void emptyConstraint() {
+        final ValueConstraints valueConstraints = ValueConstraints.empty();
+
+        assertThat(valueConstraints.getMax()).isEmpty();
+        assertThat(valueConstraints.getMin()).isEmpty();
+    }
+
+}


### PR DESCRIPTION
This PR improves the changes of PR #15. Only application specific validation errors are deprecated from the enum containing generic default values.