### PR TITLE
read media-type from @Produces annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.7.5.201505241946</version>
+        <version>0.7.6.201602180812</version>
         <executions>
           <execution>
             <id>prepare-agent</id>

--- a/src/test/java/com/mercateo/common/rest/schemagen/GenericResource.java
+++ b/src/test/java/com/mercateo/common/rest/schemagen/GenericResource.java
@@ -8,11 +8,13 @@ package com.mercateo.common.rest.schemagen;
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 
 public abstract class GenericResource<ReturnType, BeanParamType> {
 
     @GET
     @Path("{pp}")
+    @Produces("application/json")
     public ReturnType get(@BeanParam BeanParamType param) {
         return getReturnType(param);
     }

--- a/src/test/java/com/mercateo/common/rest/schemagen/ResourceClass.java
+++ b/src/test/java/com/mercateo/common/rest/schemagen/ResourceClass.java
@@ -9,10 +9,13 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Link;
 import javax.ws.rs.core.MediaType;
 
+import com.mercateo.common.rest.schemagen.link.Entry;
 import com.mercateo.common.rest.schemagen.link.LinkMetaFactory;
+import com.mercateo.common.rest.schemagen.link.LinkProperties;
 import com.mercateo.common.rest.schemagen.link.relation.Rel;
 import com.mercateo.common.rest.schemagen.types.ObjectWithSchema;
 
@@ -50,13 +53,14 @@ public class ResourceClass implements JerseyResource {
 
     @Path("/method")
     @POST
+    @LinkProperties(@Entry(key="testKey", value="testValue"))
     public void postSomething(Something something) {
         // nothing
     }
 
     @Path("/method/{id}")
     @POST
-    public void postSomethingWithId(@PathParam("id") String id, Something something) {
+    public void postSomethingWithId(@PathParam("id") String id, @QueryParam("limit") int limit) {
         // nothing
     }
 
@@ -69,6 +73,9 @@ public class ResourceClass implements JerseyResource {
     @Path("{id2}")
     public String getTwoIds(@PathParam("id") String id, @PathParam("id2") String id2) {
         return "in two ids";
+    }
+
+    public void noHttpMethod() {
     }
 
     @Path("parentResource")

--- a/src/test/java/com/mercateo/common/rest/schemagen/link/LinkFactoryTest.java
+++ b/src/test/java/com/mercateo/common/rest/schemagen/link/LinkFactoryTest.java
@@ -118,8 +118,8 @@ public class LinkFactoryTest {
     @Test
     public void testCorrectLinkGenerationPOSTWithParam() {
         Link link = linkMetaFactory.createFactoryFor(ResourceClass.class).forCall(Rel.SELF, r -> r
-                .postSomethingWithId("12", null)).get();
-        assertEquals("basePath/resource/method/12", link.getUri().toString());
+                .postSomethingWithId("12", 100)).get();
+        assertEquals("basePath/resource/method/12?limit=100", link.getUri().toString());
         assertEquals("POST", link.getParams().get("method"));
     }
 


### PR DESCRIPTION
This PR adds support to consider matching @Produces annotations on resource methods or classes.

This is a first and simple implementation. Inheritance of Annotations will be considered later on.