### PR TITLE
HTTP header names should be handled case insensitive

### DIFF
--- a/src/main/java/com/mercateo/common/rest/schemagen/link/helper/BaseUriCreator.java
+++ b/src/main/java/com/mercateo/common/rest/schemagen/link/helper/BaseUriCreator.java
@@ -5,5 +5,19 @@ import java.util.List;
 import java.util.Map;
 
 public interface BaseUriCreator {
+    /**
+     * create base uri from request origin and raw request headers
+     * @param requestBaseUri default base Uri
+     * @param requestHeaders request headers as string multimap
+     * @return base uri for link targets
+     */
     URI createBaseUri(URI requestBaseUri, Map<String, List<String>> requestHeaders);
+
+    /**
+     * create base uri from request origin and wrapped request headers
+     * @param requestBaseUri default base Uri
+     * @param requestHeaders wrapped request headers
+     * @return base uri for link targets
+     */
+    URI createBaseUri(URI requestBaseUri, HttpRequestHeaders requestHeaders);
 }

--- a/src/main/java/com/mercateo/common/rest/schemagen/link/helper/BaseUriCreatorDefault.java
+++ b/src/main/java/com/mercateo/common/rest/schemagen/link/helper/BaseUriCreatorDefault.java
@@ -2,7 +2,6 @@ package com.mercateo.common.rest.schemagen.link.helper;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -24,6 +23,11 @@ public class BaseUriCreatorDefault implements BaseUriCreator {
 
     @Override
     public URI createBaseUri(final URI requestBaseUri, final Map<String, List<String>> requestHeaders) {
+        return createBaseUri(requestBaseUri, new HttpRequestHeaders(requestHeaders));
+    }
+
+    @Override
+    public URI createBaseUri(final URI requestBaseUri, HttpRequestHeaders requestHeaders) {
 
         try {
             String scheme = requestBaseUri.getScheme();
@@ -44,22 +48,9 @@ public class BaseUriCreatorDefault implements BaseUriCreator {
         }
     }
 
-    private static Optional<String> headerValue(final Map<String, List<String>> requestHeaders,
-            final String parameterName) {
-        final List<String> requestHeader = getRequestHeader(requestHeaders, parameterName);
-        if (!requestHeader.isEmpty()) {
-            String valueFromHeader = requestHeader.get(0);
-            log.debug("use value '{}' from header {}", valueFromHeader, parameterName);
-            return Optional.ofNullable(valueFromHeader);
-        }
-        return Optional.empty();
-    }
-
-    private static List<String> getRequestHeader(final Map<String, List<String>> requestHeaders,
-            final String headerName) {
-        if (requestHeaders != null && requestHeaders.containsKey(headerName)) {
-            return requestHeaders.get(headerName);
-        }
-        return Collections.emptyList();
+    private static Optional<String> headerValue(final HttpRequestHeaders requestHeaders, final String parameterName) {
+        final Optional<String> headerValue = requestHeaders.getValues(parameterName).stream().findFirst();
+        headerValue.ifPresent(value -> log.debug("use value '{}' from header {}", value, parameterName));
+        return headerValue;
     }
 }

--- a/src/main/java/com/mercateo/common/rest/schemagen/link/helper/HttpRequestHeaders.java
+++ b/src/main/java/com/mercateo/common/rest/schemagen/link/helper/HttpRequestHeaders.java
@@ -1,0 +1,35 @@
+package com.mercateo.common.rest.schemagen.link.helper;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class HttpRequestHeaders {
+    private final Map<String, List<String>> requestHeaders;
+
+    public HttpRequestHeaders(Map<String, List<String>> requestHeaders) {
+
+        HashMap<String, List<String>> normalizedRequestHeaders = new HashMap<>();
+
+        for (Map.Entry<String, List<String>> entry : requestHeaders.entrySet()) {
+            String headerName = entry.getKey().toLowerCase();
+
+            final List<String> values = normalizedRequestHeaders.computeIfAbsent(headerName, key -> new ArrayList<>());
+            entry.getValue().stream().filter(Objects::nonNull).forEach(values::add);
+            normalizedRequestHeaders.put(headerName, values);
+        }
+
+        this.requestHeaders = normalizedRequestHeaders;
+    }
+
+    public HttpRequestHeaders(HttpRequestHeaders other) {
+        this.requestHeaders = other.requestHeaders;
+    }
+
+    public List<String> getValues(String headername) {
+        return requestHeaders.getOrDefault(headername.toLowerCase(), Collections.emptyList());
+    }
+}

--- a/src/test/java/com/mercateo/common/rest/schemagen/link/helper/BaseUriCreatorDefaultTest.java
+++ b/src/test/java/com/mercateo/common/rest/schemagen/link/helper/BaseUriCreatorDefaultTest.java
@@ -1,6 +1,7 @@
 package com.mercateo.common.rest.schemagen.link.helper;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -89,5 +90,14 @@ public class BaseUriCreatorDefaultTest {
 
         URI baseUri = baseUriFactory.createBaseUri(defaultBaseUri, requestHeaders);
         assertThat(baseUri.getScheme()).isEqualTo("https");
+    }
+
+    @Test
+    public void shouldRethrowUriSyntaxException() {
+        requestHeaders.putSingle(BaseUriCreatorDefault.HOST_HEADER, ".");
+
+        assertThatThrownBy(() -> baseUriFactory.createBaseUri(defaultBaseUri, new HttpRequestHeaders(requestHeaders)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasCauseExactlyInstanceOf(URISyntaxException.class);
     }
 }

--- a/src/test/java/com/mercateo/common/rest/schemagen/link/helper/HttpRequestHeadersTest.java
+++ b/src/test/java/com/mercateo/common/rest/schemagen/link/helper/HttpRequestHeadersTest.java
@@ -1,0 +1,68 @@
+package com.mercateo.common.rest.schemagen.link.helper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.Test;
+
+public class HttpRequestHeadersTest {
+
+    @Test
+    public void shouldIgnoreCaseOfName() throws Exception {
+        final HashMap<String, List<String>> requestHeaders = new HashMap<>();
+        requestHeaders.put("foo", Collections.singletonList("bar"));
+
+        final HttpRequestHeaders headers = new HttpRequestHeaders(requestHeaders);
+
+        assertThat(headers.getValues("Foo")).containsExactly("bar");
+    }
+
+    @Test
+    public void shouldFilterNullValues() throws Exception {
+        final HashMap<String, List<String>> requestHeaders = new HashMap<>();
+        requestHeaders.put("foo", Arrays.asList("bar", null));
+
+        final HttpRequestHeaders headers = new HttpRequestHeaders(requestHeaders);
+
+        assertThat(headers.getValues("foo")).containsExactly("bar");
+    }
+
+    @Test
+    public void shouldCreateRequestHeaders() throws Exception {
+        final HashMap<String, List<String>> requestHeaders = new HashMap<>();
+        requestHeaders.put("foo", Arrays.asList("baz", "qux"));
+        requestHeaders.put("bar", Collections.singletonList("quux"));
+
+        final HttpRequestHeaders headers = new HttpRequestHeaders(requestHeaders);
+
+        assertThat(headers.getValues("foo")).containsExactly("baz", "qux");
+        assertThat(headers.getValues("bar")).containsExactly("quux");
+    }
+
+    @Test
+    public void shouldIgnoreUppercase() throws Exception {
+        final HashMap<String, List<String>> requestHeaders = new HashMap<>();
+        requestHeaders.put("foo", Arrays.asList("baz", "qux"));
+        requestHeaders.put("Foo", Collections.singletonList("quux"));
+
+        final HttpRequestHeaders headers = new HttpRequestHeaders(requestHeaders);
+
+        assertThat(headers.getValues("foo")).containsExactlyInAnyOrder("baz", "qux", "quux");
+    }
+
+    @Test
+    public void shouldCreateCopy() throws Exception {
+        final HashMap<String, List<String>> requestHeaders = new HashMap<>();
+        requestHeaders.put("foo", Collections.singletonList("bar"));
+
+        final HttpRequestHeaders headers = new HttpRequestHeaders(requestHeaders);
+
+        final HttpRequestHeaders headersCopy = new HttpRequestHeaders(headers);
+
+        assertThat(headersCopy.getValues("foo")).containsExactly("bar");
+    }
+}


### PR DESCRIPTION
This PR adds a little abstraction which takes care of correctly accessing HTTP header values.