### PR TITLE
enable proxying of HttpRequestHeaders

### DIFF
--- a/src/main/java/com/mercateo/common/rest/schemagen/link/helper/HttpRequestHeaders.java
+++ b/src/main/java/com/mercateo/common/rest/schemagen/link/helper/HttpRequestHeaders.java
@@ -26,10 +26,14 @@ public class HttpRequestHeaders {
     }
 
     public HttpRequestHeaders(HttpRequestHeaders other) {
-        this.requestHeaders = other.requestHeaders;
+        this.requestHeaders = other.getHeaders();
     }
 
     public List<String> getValues(String headername) {
         return requestHeaders.getOrDefault(headername.toLowerCase(), Collections.emptyList());
+    }
+
+    public Map<String, List<String>> getHeaders() {
+        return requestHeaders;
     }
 }

--- a/src/test/java/com/mercateo/common/rest/schemagen/link/helper/HttpRequestHeadersTest.java
+++ b/src/test/java/com/mercateo/common/rest/schemagen/link/helper/HttpRequestHeadersTest.java
@@ -1,6 +1,7 @@
 package com.mercateo.common.rest.schemagen.link.helper;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -10,6 +11,18 @@ import java.util.List;
 import org.junit.Test;
 
 public class HttpRequestHeadersTest {
+
+    @Test
+    public void shouldReturnAllHeaders() throws Exception {
+        final HashMap<String, List<String>> requestHeaders = new HashMap<>();
+        requestHeaders.put("foo", Collections.singletonList("bar"));
+        requestHeaders.put("baz", Collections.singletonList("qux"));
+
+        final HttpRequestHeaders headers = new HttpRequestHeaders(requestHeaders);
+
+        assertThat(headers.getHeaders()).containsOnly(entry("foo", Collections.singletonList("bar")), entry("baz",
+                Collections.singletonList("qux")));
+    }
 
     @Test
     public void shouldIgnoreCaseOfName() throws Exception {


### PR DESCRIPTION
using field access for copying HttpRequestHeaders from a request scoped proxy yielded a null pointer exception